### PR TITLE
Fix: Correct Angular Material theme loading for HomeComponent

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-@import '@angular/material/prebuilt-themes/azure-blue.css';
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
Removed redundant import of the Angular Material theme from `styles.scss`. The theme was already correctly included in `angular.json`, and the duplication could lead to issues with component rendering.

With this change, Angular Material components in the HomeComponent should now display as expected.